### PR TITLE
Disable link-time optimizations

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -18,7 +18,7 @@ SRC := $(notdir $(wildcard $(SRC_DIR)/*.cpp))
 
 # Compiler options
 CC := $(WASI_SDK_PATH)/bin/clang++
-CFLAGS := --target=wasm32-wasi --sysroot=$(WASI_SDK_PATH)/share/wasi-sysroot/ -Wall -Werror -O2 -fno-exceptions -static -flto
+CFLAGS := --target=wasm32-wasi --sysroot=$(WASI_SDK_PATH)/share/wasi-sysroot/ -Wall -Werror -O2 -fno-exceptions -static
 CLIBS := -ledjx
 CPPFLAGS += -MD -MP
 


### PR DESCRIPTION
Link-time optimizations can slightly decrease the size of a compiled WASM binary. But it may cause potential issues if compiling the app with a different compiler version than the `libedjx.a` library was compiled with.