### PR TITLE
Do not use a git submodule for the EDJX SDK, expect it to be in /opt

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "edjx-cpp-sdk"]
-	path = edjx-cpp-sdk
-	url = https://github.com/edjx/edjx-cpp-sdk.git
-	branch = main

--- a/Makefile
+++ b/Makefile
@@ -2,8 +2,8 @@
 WASI_SDK_PATH := /opt/wasi-sdk
 
 # Paths to headers and SDK library
-INCLUDE_DIR := ./edjx-cpp-sdk/include
-LIB_DIR := ./edjx-cpp-sdk/lib
+INCLUDE_DIR := /opt/edjx-cpp-sdk/include
+LIB_DIR := /opt/edjx-cpp-sdk/lib
 
 # Directories used by the project
 SRC_DIR := src/


### PR DESCRIPTION
Instead of using a `./edjx-cpp-sdk` git submodule, expect the EDJX SDK to be installed in `/opt/edjx-cpp-sdk`