### PR TITLE
Specify WASI and EDJX SDK versions in the Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
 # SDK versions that will be used for compilation
 # (CHANGE THE VERSION NUMBERS IF NEEDED)
 WASI_SDK_VERSION := 12.0
-EDJX_CPP_SDK_VERSION := v21.11.1-wasi-12
+EDJX_CPP_SDK_VERSION := v22.12.1-wasi-12
 
-# Root directory of WASI SDK
+# Root directories of WASI and EDJX C++ SDKs
 WASI_SDK_PATH := $(HOME)/edjx/wasi-sdk-$(WASI_SDK_VERSION)
+EDJX_CPP_SDK_PATH := $(HOME)/edjx/edjx-cpp-sdk-$(EDJX_CPP_SDK_VERSION)
 
 # Paths to headers and SDK library
-INCLUDE_DIR := $(HOME)/edjx/edjx-cpp-sdk-$(EDJX_CPP_SDK_VERSION)/include
-LIB_DIR := $(HOME)/edjx/edjx-cpp-sdk-$(EDJX_CPP_SDK_VERSION)/lib
+INCLUDE_DIR := $(EDJX_CPP_SDK_PATH)/include
+LIB_DIR := $(EDJX_CPP_SDK_PATH)/lib
 
 # Directories used by the project
 SRC_DIR := src/
@@ -35,7 +36,22 @@ MKDIR_P := mkdir -p
 # ---------------------
 
 .PHONY: all
-all: directories $(TARGET_DIR)/$(TARGET)
+all: prerequisites directories $(TARGET_DIR)/$(TARGET)
+
+.PHONY: prerequisites
+prerequisites: $(EDJX_CPP_SDK_PATH) $(INCLUDE_DIR) $(LIB_DIR) $(WASI_SDK_PATH)
+
+$(EDJX_CPP_SDK_PATH):
+	$(error EDJX C++ SDK not found in $@. Install EDJX C++ SDK version $(EDJX_CPP_SDK_VERSION) or update the EDJX_CPP_SDK_PATH variable in the Makefile. See the EDJX documentation for the SDK installation instructions)
+
+$(INCLUDE_DIR):
+	$(error EDJX C++ SDK include directory not found in $@. Install EDJX C++ SDK version $(EDJX_CPP_SDK_VERSION) or update the INCLUDE_DIR variable in the Makefile. See the EDJX documentation for the SDK installation instructions)
+
+$(LIB_DIR):
+	$(error EDJX C++ SDK lib directory not found in $@. Install EDJX C++ SDK version $(EDJX_CPP_SDK_VERSION) or update the LIB_DIR variable in the Makefile. See the EDJX documentation for the SDK installation instructions)
+
+$(WASI_SDK_PATH):
+	$(error WASI SDK not found in $@. Install WASI SDK version $(WASI_SDK_VERSION) or update the WASI_SDK_PATH variable in the Makefile. See the EDJX documentation for the SDK installation instructions)
 
 .PHONY: directories
 directories: $(TARGET_DIR) $(BUILD_DIR)

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,14 @@
+# SDK versions that will be used for compilation
+# (CHANGE THE VERSION NUMBERS IF NEEDED)
+WASI_SDK_VERSION := 12.0
+EDJX_CPP_SDK_VERSION := v21.11.1-wasi-12
+
 # Root directory of WASI SDK
-WASI_SDK_PATH := $(HOME)/edjx/wasi-sdk
+WASI_SDK_PATH := $(HOME)/edjx/wasi-sdk-$(WASI_SDK_VERSION)
 
 # Paths to headers and SDK library
-INCLUDE_DIR := $(HOME)/edjx/edjx-cpp-sdk/include
-LIB_DIR := $(HOME)/edjx/edjx-cpp-sdk/lib
+INCLUDE_DIR := $(HOME)/edjx/edjx-cpp-sdk-$(EDJX_CPP_SDK_VERSION)/include
+LIB_DIR := $(HOME)/edjx/edjx-cpp-sdk-$(EDJX_CPP_SDK_VERSION)/lib
 
 # Directories used by the project
 SRC_DIR := src/

--- a/src/lib.cpp
+++ b/src/lib.cpp
@@ -19,7 +19,7 @@ extern HttpResponse serverless(const HttpRequest & req);
 
 int main(void) {
     HttpRequest req;
-    HttpError err = HttpRequest::from_client(req, true);
+    HttpError err = HttpRequest::from_client(req);
     if (err != HttpError::Success) {
         error(edjx::error::to_string(err));
         HttpResponse().set_status(HTTP_STATUS_BAD_REQUEST).send();


### PR DESCRIPTION
This PR updates the Makefile to the new version used by other sample functions. It doesn't use the `~/edjx/edjx-cpp-sdk` and `~/edjx/wasi-sdk` symbolic links anymore, and it prints a meaningful error message when an SDK is not installed.